### PR TITLE
fix(build): use c++17 for macos builds

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -17,7 +17,8 @@
         ],
         "OTHER_LDFLAGS": [
           "-liconv"
-        ]
+        ],
+        "CLANG_CXX_LANGUAGE_STANDARD": "c++17"
       },
       "include_dirs": [
         "<!(node -e \"require('nan')\")"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/pdffonts",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Node bindings for Poppler's pdffonts CLI",
   "main": "./lib/pdffonts.js",
   "engines": {


### PR DESCRIPTION
## What

Poppler 22.x introduced a change wherein some `GooString` instances are wrapped in an `std::optional`. This feature is only supported by C++17 and onwards.

This PR updates the `node-gyp` config to ensure the C++17 target and stdlib is used when building in MacOS 