### PR TITLE
chore(libpoppler): Fix for libpoppler

### DIFF
--- a/src/pdffonts.cc
+++ b/src/pdffonts.cc
@@ -45,7 +45,7 @@ class FontsWorker : public Nan::AsyncWorker {
       GooString gooFilename(filename.c_str());
 
       // Open PDF
-      std::unique_ptr<PDFDoc> doc(PDFDocFactory().createPDFDoc(gooFilename, nullptr, nullptr));
+      std::unique_ptr<PDFDoc> doc(PDFDocFactory().createPDFDoc(gooFilename, {}, {}));
 
       // Make sure it's a valid PDF
       if (!doc->isOk()) {
@@ -72,7 +72,7 @@ class FontsWorker : public Nan::AsyncWorker {
         v8::Local<v8::Object> fontObj = Nan::New<v8::Object>();
         v8::Local<v8::Context> context = Nan::GetCurrentContext();
 
-        if (font->getName() == NULL) {
+        if (!font->getName()) {
           fontObj->Set(context, Nan::New("name").ToLocalChecked(), Nan::Null());
         } else {
           fontObj->Set(context, Nan::New("name").ToLocalChecked(), Nan::New(font->getName()->c_str()).ToLocalChecked());


### PR DESCRIPTION
## What

[Poppler 22.05](https://poppler.freedesktop.org/releases.html) introduced changes that breaks this package. This PR updates the codebase to work with the changes to the library

The errors fixed by this change are
- `../src/pdffonts.cc:48:77: error: reference to type 'const std::optional<GooString>' could not bind to an rvalue of type 'nullptr_t'
      std::unique_ptr<PDFDoc> doc(PDFDocFactory().createPDFDoc(gooFilename, nullptr, nullptr));`
- `../src/pdffonts.cc:75:29: error: invalid operands to binary expression ('const std::optional<std::string>' (aka 'const optional<basic_string<char, char_traits<char>, allocator<char>>>') and 'long')`

## Testing (Locally)

1. Ensure you have the latest version of Poppler installed `brew install poppler`
1. `npm run test`

## Testing (21.06.01-r1)

1. `docker build --build-arg NODE_ENV=development -t pdffonts-test .`
2. `docker run -ti --rm pdffonts-test npm test` 