### PR TITLE
PLAT-2193: update deprecated GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build container image
         run: docker build --build-arg NODE_ENV=development -t "$CONTAINER_IMAGE" .


### PR DESCRIPTION
## JIRA

* [PLAT-2193](https://lobsters.atlassian.net/browse/PLAT-2193)

## Description

* `actions/checkout@v2` runs Node 12 and is deprecated, we need this to run Node 20:

See:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
and
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

---