### PR TITLE
RC-3277 publish on pushes to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -89,3 +89,6 @@ $ npm run cover:html
 ```bash
 $ npm run lint
 ```
+
+## Publishing to npm
+Our github action "Publish" automatically publishes the package to npm upon pushes to the 'main' branch

--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ $ npm run lint
 ```
 
 ## Publishing to npm
-Our github action "Publish" automatically publishes the package to npm upon pushes to the 'main' branch
+Our GitHub action "Publish" automatically publishes the package to npm upon pushes to the `main` branch


### PR DESCRIPTION
Fixed the job publish description to run on pushes to 'main', not 'master'